### PR TITLE
typo: Excellent coffee should have high quality

### DIFF
--- a/book/004-functions-classes.md
+++ b/book/004-functions-classes.md
@@ -181,7 +181,7 @@ class Coffee {
   }
 
   static isExcellentCoffee(Coffee) {
-    return Coffee.quality < 80;
+    return Coffee.quality > 80;
   }
 }
 ```


### PR DESCRIPTION
I would expect "higher quality" to correspond with "excellent coffee".